### PR TITLE
fix: sync slash command tree on startup

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -104,7 +104,8 @@ class VRChatAnnounceBot(commands.Bot):
             await self.add_cog(AnnouncementCog(self, self.config, self.ai_processor, self.scheduler))
             await self.add_cog(AdminCog(self, self.config, self.scheduler))
             await self.add_cog(GeneralCog(self))
-            
+
+            await self.tree.sync()
             logger.info(Messages.Log.BOT_SETUP_SUCCESS)
             
         except Exception as e:


### PR DESCRIPTION
## Summary

- `/list`, `/cancel`, and `/help` slash commands were never registered with Discord because `tree.sync()` was never called after loading cogs
- Added `await self.tree.sync()` in `setup_hook` after all cogs are added

## Root cause

`@commands.hybrid_command` registers commands both as prefix commands and as slash commands locally, but Discord's API only learns about slash commands when the bot explicitly syncs the command tree via `tree.sync()`. Without this call, the local tree is never uploaded to Discord, so only `!` prefix commands worked.

## Test plan

- [ ] Start the bot and confirm `/list`, `/cancel`, and `/help` appear as slash commands in Discord
- [ ] Confirm `!list`, `!cancel`, and `!help` prefix commands still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)