### PR TITLE
refactor: improve readability with typed models, state manager, and auth-retry helper

### DIFF
--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -47,13 +47,13 @@ class AdminCog(commands.Cog):
         
         for job in jobs:
             # Trim content if too long
-            content = job["content"]
+            content = job.content
             if len(content) > 100:
                 content = content[:97] + "..."
-                
+
             embed.add_field(
-                name=f"ID: {job['id']} - <t:{int(job['timestamp'])}:F>",
-                value=f"タイトル: {job['title']}\n内容: {content}",
+                name=f"ID: {job.id} - <t:{int(job.timestamp)}:F>",
+                value=f"タイトル: {job.title}\n内容: {content}",
                 inline=False
             )
             

--- a/cogs/announcement.py
+++ b/cogs/announcement.py
@@ -6,35 +6,58 @@ import asyncio
 import uuid
 import time
 from utils.messages import Messages
+from utils.announcement_state import AnnouncementState
 
 logger = logging.getLogger(__name__)
 
 class AnnouncementCog(commands.Cog):
-    def __init__(self, bot, config, ai_processor, scheduler, persistence):
+    def __init__(self, bot, config, ai_processor, scheduler, persistence, vrchat_api):
         self.bot = bot
         self.config = config
         self.ai_processor = ai_processor
         self.scheduler = scheduler
+        self.vrchat_api = vrchat_api
         self.channel_ids = config['discord']['channel_ids']  # List of channel IDs to monitor
         self.admin_role_id = config['discord']['admin_role_id']
         self.seen_emoji = config['discord'].get('seen_reaction_emoji', "👀")
         self.approval_emoji = config['discord'].get('approval_reaction_emoji', "👍")
         self.fast_forward_emoji = config['discord'].get('fast_forward_emoji', "⏩")
         self.calendar_emoji = config['discord'].get('calendar_emoji', "📅")
-        self.pending_requests = {}  # Store message IDs and their scheduled message IDs
-        self.calendar_events = {} # Store message IDs and their calendar event IDs
-        self.queued_announcements = set()  # Store message IDs that have been queued
-        self.history = [] # List of completed message IDs (limit 1000)
+        self.state = AnnouncementState()
         self.otp_requests = {}  # Store OTP requests and their futures
         self.persistence = persistence
 
         # Set up OTP callback for VRChat API
-        self.scheduler.vrchat_api.set_otp_callback(self._request_otp)
+        self.vrchat_api.set_otp_callback(self._request_otp)
 
         # Set up job completion callback
         self.scheduler.set_on_job_completion(self._on_job_complete)
 
         # Load state will be called in on_ready
+
+    # --- State persistence ---
+
+    async def save_state(self):
+        """Save the current state to Firestore"""
+        await self.state.save(self.persistence)
+        await self.persistence.save_data('jobs', self.scheduler.get_jobs_data())
+
+    async def load_state(self):
+        """Load state from Firestore"""
+        await self.state.load(self.persistence)
+
+        jobs_data = await self.persistence.load_data('jobs', [])
+        restored_count, skipped_jobs = self.scheduler.restore_jobs(jobs_data)
+
+        # Rebuild queued_announcements from restored jobs
+        self.state.queued_announcements = set()
+        for job in self.scheduler.list_jobs():
+            if job.message_id:
+                self.state.queued_announcements.add(job.message_id)
+
+        return restored_count, len(self.state.pending_requests), skipped_jobs
+
+    # --- Callbacks ---
 
     async def _on_job_complete(self, job_data):
         """Callback for when a job completes (success or failure)"""
@@ -43,20 +66,7 @@ class AnnouncementCog(commands.Cog):
             status = job_data.get('status', 'success')
 
             if message_id and status == 'success':
-                # Add to history
-                if message_id not in self.history:
-                    self.history.append(message_id)
-                    # Limit history to 1000 items
-                    if len(self.history) > 1000:
-                        self.history = self.history[-1000:]
-
-                # Remove from queued list
-                if message_id in self.queued_announcements:
-                    self.queued_announcements.remove(message_id)
-
-                # Remove from pending requests (request complete)
-                if message_id in self.pending_requests:
-                    del self.pending_requests[message_id]
+                self.state.mark_completed(message_id)
 
             # Save state for both success and failure
             await self.save_state()
@@ -64,54 +74,7 @@ class AnnouncementCog(commands.Cog):
         except Exception as e:
             logger.error(f"Error in job completion callback: {e}")
 
-    async def save_state(self):
-        """Save the current state to Firestore"""
-        await self.persistence.save_data('pending', self.pending_requests)
-        await self.persistence.save_data('history', self.history)
-        await self.persistence.save_data('jobs', self.scheduler.get_jobs_data())
-        await self.persistence.save_data('calendar', self.calendar_events)
-
-    async def load_state(self):
-        """Load state from Firestore"""
-        self.pending_requests = await self.persistence.load_data('pending', {})
-        self.history = await self.persistence.load_data('history', [])
-        self.calendar_events = await self.persistence.load_data('calendar', {})
-
-        jobs_data = await self.persistence.load_data('jobs', [])
-        restored_count, skipped_jobs = self.scheduler.restore_jobs(jobs_data)
-
-        # Rebuild queued_announcements from restored jobs
-        self.queued_announcements = set()
-        for job in self.scheduler.list_jobs():
-            if 'message_id' in job:
-                self.queued_announcements.add(job['message_id'])
-
-        return restored_count, len(self.pending_requests), skipped_jobs
-
-    @commands.Cog.listener()
-    async def on_ready(self):
-        """Called when the bot is ready"""
-        try:
-            # Load state
-            restored_jobs, pending_count, skipped_jobs = await self.load_state()
-
-            # Immediately save state to clean up any skipped jobs from jobs
-            await self.save_state()
-
-            # Send restoration message
-            channel = self.bot.get_channel(self.channel_ids[0])
-            if channel:
-                msg = Messages.Discord.RESTORATION_STATS.format(pending_count, restored_jobs)
-                await channel.send(msg)
-
-                # Notify about skipped jobs
-                if skipped_jobs:
-                    skipped_titles = [f"- {job['title']}" for job in skipped_jobs]
-                    skipped_msg = Messages.Discord.SKIPPED_JOBS.format(len(skipped_jobs), "\n".join(skipped_titles))
-                    await channel.send(skipped_msg)
-
-        except Exception as e:
-            logger.error(f"Error during announcement cog initialization: {e}")
+    # --- OTP handling ---
 
     async def _request_otp(self, otp_type):
         """Request OTP from admin through Discord"""
@@ -143,6 +106,33 @@ class AnnouncementCog(commands.Cog):
             # Clean up
             if request_id in self.otp_requests:
                 del self.otp_requests[request_id]
+
+    # --- Message listener ---
+
+    @commands.Cog.listener()
+    async def on_ready(self):
+        """Called when the bot is ready"""
+        try:
+            # Load state
+            restored_jobs, pending_count, skipped_jobs = await self.load_state()
+
+            # Immediately save state to clean up any skipped jobs from jobs
+            await self.save_state()
+
+            # Send restoration message
+            channel = self.bot.get_channel(self.channel_ids[0])
+            if channel:
+                msg = Messages.Discord.RESTORATION_STATS.format(pending_count, restored_jobs)
+                await channel.send(msg)
+
+                # Notify about skipped jobs
+                if skipped_jobs:
+                    skipped_titles = [f"- {job['title']}" for job in skipped_jobs]
+                    skipped_msg = Messages.Discord.SKIPPED_JOBS.format(len(skipped_jobs), "\n".join(skipped_titles))
+                    await channel.send(skipped_msg)
+
+        except Exception as e:
+            logger.error(f"Error during announcement cog initialization: {e}")
 
     @commands.Cog.listener()
     async def on_message(self, message):
@@ -176,17 +166,15 @@ class AnnouncementCog(commands.Cog):
     async def _handle_announcement_request(self, message):
         """Handle a new announcement request"""
         try:
-            # Check if this message has already been queued or sent
-            if str(message.id) in self.queued_announcements:
-                await message.reply(Messages.Discord.ALREADY_BOOKED)
-                return
+            msg_id = str(message.id)
 
-            if str(message.id) in self.history:
+            # Check if this message has already been queued or sent
+            if self.state.is_queued(msg_id) or self.state.is_in_history(msg_id):
                 await message.reply(Messages.Discord.ALREADY_BOOKED)
                 return
 
             # Simply store the message ID and add reaction
-            self.pending_requests[str(message.id)] = None  # Will store scheduled message ID later
+            self.state.add_pending(msg_id)
             await self.save_state()
             await message.add_reaction(self.seen_emoji)
             await message.reply(Messages.Discord.REQUEST_CONFIRMED)
@@ -194,6 +182,8 @@ class AnnouncementCog(commands.Cog):
         except Exception as e:
             logger.error(Messages.Log.ANNOUNCEMENT_REQUEST_ERROR.format(e))
             await message.reply(Messages.Discord.ERROR_OCCURRED.format(str(e)))
+
+    # --- Reaction handlers ---
 
     @commands.Cog.listener()
     async def on_raw_reaction_add(self, payload):
@@ -210,125 +200,65 @@ class AnnouncementCog(commands.Cog):
         if not channel:
             return
 
-        # Get member to check roles
-        try:
-            member = await channel.guild.fetch_member(payload.user_id)
-        except:
-            return
+        emoji = str(payload.emoji)
+        msg_id = str(payload.message_id)
 
         # Case 1: Approval of pending request (Reaction to User's message)
-        if str(payload.message_id) in self.pending_requests:
-            # Check for approval reaction and admin role
-            if str(payload.emoji) == self.approval_emoji:
-                if not member or self.admin_role_id not in [role.id for role in member.roles]:
-                    return
-
-                message = await channel.fetch_message(payload.message_id)
-                if not message:
-                    return
-
-                # Check if this message has already been queued
-                if str(message.id) in self.queued_announcements:
-                    return
-
-                # Check if this message has already been sent (history)
-                if str(message.id) in self.history:
-                    return
-
-                # Process the approved announcement
-                await self._process_approved_announcement(message)
+        if emoji == self.approval_emoji and self.state.is_pending(msg_id):
+            member = await self._fetch_member_safe(channel, payload.user_id)
+            if not self._is_admin(member):
                 return
+
+            if self.state.is_queued(msg_id) or self.state.is_in_history(msg_id):
+                return
+
+            message = await channel.fetch_message(payload.message_id)
+            if message:
+                await self._process_approved_announcement(message)
+            return
 
         # Case 2: Immediate posting of queued announcement (Reaction to Bot's message)
-        if str(payload.emoji) == self.fast_forward_emoji:
-            # Find the original request ID based on the bot's message ID (queued message)
-            request_msg_id = None
-            for req_id, queued_msg_id in self.pending_requests.items():
-                if queued_msg_id == str(payload.message_id):
-                    request_msg_id = req_id
-                    break
-
-            if request_msg_id:
-                # Get the original request message to check author
-                try:
-                    request_message = await channel.fetch_message(int(request_msg_id))
-
-                    # Check permissions: Admin or Original Author
-                    is_admin = member and self.admin_role_id in [role.id for role in member.roles]
-                    is_author = request_message.author.id == payload.user_id
-
-                    if is_admin or is_author:
-                        await self._process_immediate_post(request_msg_id, payload.channel_id, payload.message_id)
-                except Exception as e:
-                    logger.error(f"Error handling immediate post request: {e}")
+        if emoji == self.fast_forward_emoji:
+            await self._handle_fast_forward_reaction(channel, payload)
+            return
 
         # Case 3: Create Calendar Event (Reaction to Bot's message)
-        if str(payload.emoji) == self.calendar_emoji:
-            # Find the original request ID based on the bot's message ID (booked message)
-            request_msg_id = None
-            for req_id, queued_msg_id in self.pending_requests.items():
-                if queued_msg_id == str(payload.message_id):
-                    request_msg_id = req_id
-                    break
+        if emoji == self.calendar_emoji:
+            await self._handle_calendar_reaction(channel, payload)
 
-            if request_msg_id:
-                # Check if event already exists
-                if str(request_msg_id) in self.calendar_events:
-                    return
+    async def _handle_fast_forward_reaction(self, channel, payload):
+        """Handle fast-forward reaction to immediately post a queued announcement"""
+        request_msg_id = self.state.find_request_id_by_bot_message(str(payload.message_id))
+        if not request_msg_id:
+            return
 
-                # Get the original request message to check author
-                try:
-                    request_message = await channel.fetch_message(int(request_msg_id))
-
-                    # Verify user is Author or Admin
-                    is_admin = member and self.admin_role_id in [role.id for role in member.roles]
-                    is_author = request_message.author.id == payload.user_id
-
-                    if is_admin or is_author:
-                        await self._process_calendar_event_creation(request_message, channel)
-                except Exception as e:
-                    logger.error(f"Error handling calendar event creation: {e}")
-
-    async def _process_calendar_event_creation(self, message, channel):
-        """Process the creation of a VRChat calendar event"""
         try:
-            job = self.scheduler.get_job_by_message_id(str(message.id))
-            if not job:
-                logger.warning(Messages.Log.CALENDAR_EVENT_CREATE_WARNING.format(message.id))
-                return
+            request_message = await channel.fetch_message(int(request_msg_id))
+            member = await self._fetch_member_safe(channel, payload.user_id)
 
-            # Retrieve event details from job
-            title = job.get('event_title', job['title'])
-            content = job['content']
-            start_at = job.get('event_start_timestamp')
-            end_at = job.get('event_end_timestamp')
-
-            if not start_at or not end_at:
-                await channel.send(Messages.Discord.CALENDAR_MISSING_TIME)
-                return
-
-            # Call VRChat API
-            result = await self.scheduler.vrchat_api.create_group_calendar_event(title, content, start_at, end_at)
-
-            if result['success']:
-                calendar_id = result['event_id']
-                group_id = self.scheduler.vrchat_api.group_id
-
-                # Store event ID
-                self.calendar_events[str(message.id)] = calendar_id
-                await self.save_state()
-
-                # Send success message
-                calendar_url = f"https://vrchat.com/home/group/{group_id}/calendar/{calendar_id}"
-                await channel.send(Messages.Discord.CALENDAR_CREATED.format(calendar_url))
-            else:
-                error_msg = result.get('error', 'Unknown error')
-                await channel.send(Messages.Discord.CALENDAR_CREATE_FAIL.format(error_msg))
-                logger.error(Messages.Log.CALENDAR_EVENT_CREATE_FAIL.format(error_msg))
-
+            if self._is_admin(member) or request_message.author.id == payload.user_id:
+                await self._process_immediate_post(request_msg_id, payload.channel_id, payload.message_id)
         except Exception as e:
-            logger.error(Messages.Log.CALENDAR_EVENT_CREATE_EXCEPTION.format(e))
-            await channel.send(Messages.Discord.ERROR_OCCURRED.format(str(e)))
+            logger.error(f"Error handling immediate post request: {e}")
+
+    async def _handle_calendar_reaction(self, channel, payload):
+        """Handle calendar reaction to create a VRChat calendar event"""
+        request_msg_id = self.state.find_request_id_by_bot_message(str(payload.message_id))
+        if not request_msg_id:
+            return
+
+        # Check if event already exists
+        if self.state.has_calendar_event(request_msg_id):
+            return
+
+        try:
+            request_message = await channel.fetch_message(int(request_msg_id))
+            member = await self._fetch_member_safe(channel, payload.user_id)
+
+            if self._is_admin(member) or request_message.author.id == payload.user_id:
+                await self._process_calendar_event_creation(request_message, channel)
+        except Exception as e:
+            logger.error(f"Error handling calendar event creation: {e}")
 
     @commands.Cog.listener()
     async def on_raw_reaction_remove(self, payload):
@@ -345,76 +275,133 @@ class AnnouncementCog(commands.Cog):
         if not channel:
             return
 
+        emoji = str(payload.emoji)
+
         # Case: Removal of Calendar reaction
-        if str(payload.emoji) == self.calendar_emoji:
-            # The reaction is removed from the bot's message.
-            # We need to find the original request ID.
-            request_msg_id = None
-            for req_id, queued_msg_id in self.pending_requests.items():
-                if queued_msg_id == str(payload.message_id):
-                    request_msg_id = req_id
-                    break
-
-            if request_msg_id and str(request_msg_id) in self.calendar_events:
-                try:
-                     member = await channel.guild.fetch_member(payload.user_id)
-                     # Get original request message to check permissions
-                     request_message = await channel.fetch_message(int(request_msg_id))
-
-                     is_admin = member and self.admin_role_id in [role.id for role in member.roles]
-                     is_author = request_message.author.id == payload.user_id
-
-                     if is_admin or is_author:
-                        calendar_event_id = self.calendar_events[str(request_msg_id)]
-                        result = await self.scheduler.vrchat_api.delete_group_calendar_event(calendar_event_id)
-                        del self.calendar_events[str(request_msg_id)]
-                        await self.save_state()
-                        if result['success']:
-                            await channel.send(Messages.Discord.CALENDAR_DELETED)
-                        else:
-                            await channel.send(result['error'])
-                except Exception as e:
-                    logger.error(Messages.Log.CALENDAR_EVENT_DELETE_ERROR.format(e))
+        if emoji == self.calendar_emoji:
+            await self._handle_calendar_reaction_remove(channel, payload)
 
         # Case: Removal of Approval reaction (on User's message)
-        # Note: pending_requests keys are user's message IDs (as strings)
-        elif str(payload.emoji) == self.approval_emoji:
-            # Check if this message (user's message) is in queued announcements
-            if str(payload.message_id) not in self.queued_announcements:
+        elif emoji == self.approval_emoji:
+            await self._handle_approval_reaction_remove(channel, payload)
+
+    async def _handle_calendar_reaction_remove(self, channel, payload):
+        """Handle removal of calendar reaction to delete the VRChat calendar event"""
+        request_msg_id = self.state.find_request_id_by_bot_message(str(payload.message_id))
+        if not request_msg_id or not self.state.has_calendar_event(request_msg_id):
+            return
+
+        try:
+            member = await channel.guild.fetch_member(payload.user_id)
+            request_message = await channel.fetch_message(int(request_msg_id))
+
+            if not (self._is_admin(member) or request_message.author.id == payload.user_id):
                 return
 
-            message = await channel.fetch_message(payload.message_id)
-            if not message:
+            calendar_event_id = self.state.remove_calendar_event(request_msg_id)
+            result = await self.vrchat_api.delete_group_calendar_event(calendar_event_id)
+            await self.save_state()
+            if result.success:
+                await channel.send(Messages.Discord.CALENDAR_DELETED)
+            else:
+                await channel.send(result.error)
+        except Exception as e:
+            logger.error(Messages.Log.CALENDAR_EVENT_DELETE_ERROR.format(e))
+
+    async def _handle_approval_reaction_remove(self, channel, payload):
+        """Handle removal of approval reaction to cancel a queued announcement"""
+        msg_id = str(payload.message_id)
+        if not self.state.is_queued(msg_id):
+            return
+
+        message = await channel.fetch_message(payload.message_id)
+        if not message:
+            return
+
+        # Check if there are any approval reactions left
+        approval_reactions = [r for r in message.reactions if str(r.emoji) == self.approval_emoji]
+        if approval_reactions and approval_reactions[0].count > 0:
+            return
+
+        # Cancel the job and delete the scheduled message
+        if not self.scheduler.cancel_job_by_message_id(msg_id):
+            return
+
+        bot_reply_id = self.state.get_bot_reply_id(msg_id)
+        if bot_reply_id:
+            try:
+                scheduled_msg = await channel.fetch_message(bot_reply_id)
+                if scheduled_msg:
+                    await scheduled_msg.delete()
+            except Exception as e:
+                logger.error(Messages.Log.SCHEDULED_MSG_DELETE_ERROR.format(e))
+
+        # Also delete calendar event if exists
+        calendar_event_id = self.state.cancel(msg_id)
+        if calendar_event_id:
+            await self.vrchat_api.delete_group_calendar_event(calendar_event_id)
+            await channel.send(Messages.Discord.CALENDAR_DELETED_WITH_CANCEL)
+
+        await self.save_state()
+        await message.reply(Messages.Discord.BOOKING_CANCELLED)
+
+    # --- Permission helpers ---
+
+    async def _fetch_member_safe(self, channel, user_id):
+        """Fetch a guild member, returning None on failure."""
+        try:
+            return await channel.guild.fetch_member(user_id)
+        except Exception:
+            return None
+
+    def _is_admin(self, member) -> bool:
+        """Check if a member has the admin role."""
+        if not member:
+            return False
+        return self.admin_role_id in [role.id for role in member.roles]
+
+    # --- Business logic ---
+
+    async def _process_calendar_event_creation(self, message, channel):
+        """Process the creation of a VRChat calendar event"""
+        try:
+            job = self.scheduler.get_job_by_message_id(str(message.id))
+            if not job:
+                logger.warning(Messages.Log.CALENDAR_EVENT_CREATE_WARNING.format(message.id))
                 return
 
-            # Check if there are any approval reactions left
-            approval_reactions = [r for r in message.reactions if str(r.emoji) == self.approval_emoji]
-            if not approval_reactions or approval_reactions[0].count == 0:
-                # Cancel the job and delete the scheduled message
-                if self.scheduler.cancel_job_by_message_id(str(message.id)):
-                    scheduled_msg_id = self.pending_requests.get(str(message.id))
-                    if scheduled_msg_id:
-                        try:
-                            scheduled_msg = await channel.fetch_message(scheduled_msg_id)
-                            if scheduled_msg:
-                                await scheduled_msg.delete()
-                        except Exception as e:
-                            logger.error(Messages.Log.SCHEDULED_MSG_DELETE_ERROR.format(e))
+            # Retrieve event details from job
+            title = job.event_title or job.title
+            content = job.content
+            start_at = job.event_start_timestamp
+            end_at = job.event_end_timestamp
 
-                    # Also delete calendar event if exists
-                    if str(message.id) in self.calendar_events:
-                        calendar_event_id = self.calendar_events[str(message.id)]
-                        await self.scheduler.vrchat_api.delete_group_calendar_event(calendar_event_id)
-                        del self.calendar_events[str(message.id)]
-                        await channel.send(Messages.Discord.CALENDAR_DELETED_WITH_CANCEL)
+            if not start_at or not end_at:
+                await channel.send(Messages.Discord.CALENDAR_MISSING_TIME)
+                return
 
-                    # Clean up tracking - keep in pending_requests but clear scheduled message ID
-                    if str(message.id) in self.queued_announcements:
-                        self.queued_announcements.remove(str(message.id))
-                    self.pending_requests[str(message.id)] = None
+            # Call VRChat API
+            result = await self.vrchat_api.create_group_calendar_event(title, content, start_at, end_at)
 
-                    await self.save_state()
-                    await message.reply(Messages.Discord.BOOKING_CANCELLED)
+            if result.success:
+                calendar_id = result.data['event_id']
+                group_id = self.vrchat_api.group_id
+
+                # Store event ID
+                self.state.set_calendar_event(str(message.id), calendar_id)
+                await self.save_state()
+
+                # Send success message
+                calendar_url = f"https://vrchat.com/home/group/{group_id}/calendar/{calendar_id}"
+                await channel.send(Messages.Discord.CALENDAR_CREATED.format(calendar_url))
+            else:
+                error_msg = result.error or 'Unknown error'
+                await channel.send(Messages.Discord.CALENDAR_CREATE_FAIL.format(error_msg))
+                logger.error(Messages.Log.CALENDAR_EVENT_CREATE_FAIL.format(error_msg))
+
+        except Exception as e:
+            logger.error(Messages.Log.CALENDAR_EVENT_CREATE_EXCEPTION.format(e))
+            await channel.send(Messages.Discord.ERROR_OCCURRED.format(str(e)))
 
     async def _process_immediate_post(self, request_msg_id, channel_id, processing_msg_id):
         """Process an immediate post request"""
@@ -430,45 +417,62 @@ class AnnouncementCog(commands.Cog):
         processing_msg = await channel.fetch_message(processing_msg_id)
 
         # Cancel the scheduled job
-        self.scheduler.cancel_job(job['id'])
+        self.scheduler.cancel_job(job.id)
 
         # Post immediately
         try:
-            result = await self.scheduler.vrchat_api.post_announcement(job['title'], job['content'])
+            result = await self.vrchat_api.post_announcement(job.title, job.content)
 
-            if result['success']:
+            if result.success:
                 # Update embed to show success
                 embed = processing_msg.embeds[0]
                 embed.color = discord.Color.gold()
                 embed.title = Messages.Discord.IMMEDIATE_POST_SUCCESS
                 embed.description = Messages.Discord.IMMEDIATE_POST_EXECUTED
-                # Remove timestamp field if needed, or update it
-                # For now just updating title and color
 
                 await processing_msg.edit(embed=embed)
 
-                # Clean up tracking
-                if str(request_msg_id) in self.queued_announcements:
-                    self.queued_announcements.remove(str(request_msg_id))
-
-                # Add to history
-                if str(request_msg_id) not in self.history:
-                    self.history.append(str(request_msg_id))
-                    if len(self.history) > 1000:
-                        self.history = self.history[-1000:]
+                # Mark completed in state
+                self.state.mark_completed(str(request_msg_id))
+                # Keep pending_requests entry as it maps to the processing msg which still exists
+                self.state.pending_requests[str(request_msg_id)] = str(processing_msg_id)
 
                 await self.save_state()
-                # We keep pending_requests as it maps to the processing msg which still exists
             else:
-                # BUG FIX: Save state even on failure — the job was already cancelled
+                # Save state even on failure - the job was already cancelled
                 await self.save_state()
-                await channel.send(Messages.Discord.IMMEDIATE_POST_FAIL.format(result['error']))
+                await channel.send(Messages.Discord.IMMEDIATE_POST_FAIL.format(result.error))
 
         except Exception as e:
             logger.error(f"Error in immediate post: {e}")
-            # BUG FIX: Save state even on exception — the job was already cancelled
+            # Save state even on exception - the job was already cancelled
             await self.save_state()
             await channel.send(Messages.Discord.IMMEDIATE_POST_FAIL.format(str(e)))
+
+    def _is_timestamp_too_old(self, timestamp) -> bool:
+        """Check if a timestamp is more than 1 hour in the past."""
+        return timestamp < time.time() - 3600
+
+    def _build_booking_embed(self, result, job_id) -> discord.Embed:
+        """Build the confirmation embed for a booked announcement."""
+        embed = discord.Embed(
+            title=Messages.Discord.BOOKING_COMPLETED_TITLE,
+            color=discord.Color.green()
+        )
+        embed.add_field(name="告知予定時刻", value=f"<t:{int(result.announcement_timestamp)}:F>", inline=False)
+        embed.add_field(name="イベント開始", value=f"<t:{int(result.event_start_timestamp)}:F>", inline=False)
+        embed.add_field(name="イベント終了", value=f"<t:{int(result.event_end_timestamp)}:F>", inline=False)
+
+        embed.add_field(name=Messages.Discord.FIELD_TITLE, value=result.title, inline=False)
+
+        content = result.content
+        if len(content) > 1024:
+            content = content[:1021] + "..."
+        embed.add_field(name=Messages.Discord.FIELD_CONTENT, value=content, inline=False)
+        embed.add_field(name=Messages.Discord.FIELD_JOB_ID, value=job_id, inline=False)
+        embed.add_field(name=Messages.Discord.FIELD_HINTS, value=Messages.Discord.FIELD_HINTS_CONTENTS, inline=False)
+
+        return embed
 
     async def _process_approved_announcement(self, message):
         """Process an approved announcement request"""
@@ -479,60 +483,38 @@ class AnnouncementCog(commands.Cog):
             # Process with AI using the current message content
             result = await self.ai_processor.process_announcement(message.content)
 
-            if not result["success"]:
-                await processing_msg.edit(content=Messages.Discord.ERROR_OCCURRED.format(result['error']))
+            if not result.success:
+                await processing_msg.edit(content=Messages.Discord.ERROR_OCCURRED.format(result.error))
                 return
 
-            # Check if timestamp is in the past (more than 1 hour ago)
-            current_timestamp = time.time()
-            if result["timestamp"] < current_timestamp - 3600:
+            # Check if timestamp is too far in the past
+            if self._is_timestamp_too_old(result.timestamp):
                 role_mention = f"<@&{self.admin_role_id}>"
                 author_mention = message.author.mention
                 mentions = f"{role_mention} {author_mention}"
-
                 await processing_msg.edit(content=Messages.Discord.PAST_TIME_WARNING.format(mentions=mentions))
                 return
 
             # Schedule the announcement
             job_id = await self.scheduler.schedule_announcement(
-                result["announcement_timestamp"],
-                result["title"],
-                result["content"],
+                result.announcement_timestamp,
+                result.title,
+                result.content,
                 str(message.id),
-                event_start_timestamp=result["event_start_timestamp"],
-                event_end_timestamp=result["event_end_timestamp"],
-                event_title=result.get("event_title")
+                event_start_timestamp=result.event_start_timestamp,
+                event_end_timestamp=result.event_end_timestamp,
+                event_title=result.event_title,
             )
 
-            # Create confirmation embed
-            embed = discord.Embed(
-                title=Messages.Discord.BOOKING_COMPLETED_TITLE,
-                color=discord.Color.green()
-            )
-            embed.add_field(name="告知予定時刻", value=f"<t:{int(result['announcement_timestamp'])}:F>", inline=False)
-            embed.add_field(name="イベント開始", value=f"<t:{int(result['event_start_timestamp'])}:F>", inline=False)
-            embed.add_field(name="イベント終了", value=f"<t:{int(result['event_end_timestamp'])}:F>", inline=False)
-
-            embed.add_field(name=Messages.Discord.FIELD_TITLE, value=result["title"], inline=False)
-
-            content = result["content"]
-            if len(content) > 1024:
-                content = content[:1021] + "..."
-            embed.add_field(name=Messages.Discord.FIELD_CONTENT, value=content, inline=False)
-            embed.add_field(name=Messages.Discord.FIELD_JOB_ID, value=job_id, inline=False)
-            embed.add_field(name=Messages.Discord.FIELD_HINTS, value=Messages.Discord.FIELD_HINTS_CONTENTS, inline=False)
-
-            # Update the processing message with the final result
+            # Build and send confirmation embed
+            embed = self._build_booking_embed(result, job_id)
             await processing_msg.edit(content=None, embed=embed)
 
-            # Store the processing message ID for potential cancellation
-            self.pending_requests[str(message.id)] = str(processing_msg.id)
-            self.queued_announcements.add(str(message.id))
+            # Update state
+            self.state.mark_queued(str(message.id), str(processing_msg.id))
 
-            # Add calendar reaction for quick access
+            # Add calendar and fast-forward reactions for quick access
             await processing_msg.add_reaction(self.calendar_emoji)
-
-            # Add fast forward reaction for quick access
             await processing_msg.add_reaction(self.fast_forward_emoji)
 
             await self.save_state()

--- a/tests/test_ai_processor.py
+++ b/tests/test_ai_processor.py
@@ -38,15 +38,15 @@ async def test_process_announcement_success(ai_processor):
 
         result = await ai_processor.process_announcement("Test message")
 
-        assert result['success'] is True
-        assert result['title'] == "Test Event"
-        assert result['content'] == "Test Content"
-        assert result['event_title'] == "Test Event" # Fallback check
+        assert result.success is True
+        assert result.title == "Test Event"
+        assert result.content == "Test Content"
+        assert result.event_title == "Test Event" # Fallback check
 
         # Verify timestamps (approximate check due to timezone complexity in test env vs implementation)
         # Just check relative order
-        assert result['announcement_timestamp'] < result['event_start_timestamp']
-        assert result['event_start_timestamp'] < result['event_end_timestamp']
+        assert result.announcement_timestamp < result.event_start_timestamp
+        assert result.event_start_timestamp < result.event_end_timestamp
 
         # Check specific values (JST is UTC+9)
         # Announcement: 2023-10-27 20:00 JST -> 2023-10-27 11:00 UTC
@@ -54,7 +54,7 @@ async def test_process_announcement_success(ai_processor):
 
         jst = pytz.timezone('Asia/Tokyo')
         ann_dt = jst.localize(datetime(2023, 10, 27, 20, 0))
-        assert result['announcement_timestamp'] == int(ann_dt.timestamp())
+        assert result.announcement_timestamp == int(ann_dt.timestamp())
 
 @pytest.mark.asyncio
 async def test_process_announcement_with_event_title(ai_processor):
@@ -79,9 +79,9 @@ async def test_process_announcement_with_event_title(ai_processor):
 
         result = await ai_processor.process_announcement("Test message")
 
-        assert result['success'] is True
-        assert result['title'] == "Application Title"
-        assert result['event_title'] == "Event Title"
+        assert result.success is True
+        assert result.title == "Application Title"
+        assert result.event_title == "Event Title"
 
 @pytest.mark.asyncio
 async def test_process_announcement_truncation(ai_processor):
@@ -106,11 +106,11 @@ async def test_process_announcement_truncation(ai_processor):
 
         result = await ai_processor.process_announcement("Test message")
 
-        assert result['success'] is True
-        assert len(result['title']) == 128
-        assert len(result['event_title']) == 128
-        assert result['title'] == "A" * 128
-        assert result['event_title'] == "B" * 128
+        assert result.success is True
+        assert len(result.title) == 128
+        assert len(result.event_title) == 128
+        assert result.title == "A" * 128
+        assert result.event_title == "B" * 128
 
 @pytest.mark.asyncio
 async def test_process_announcement_missing_end_time(ai_processor):
@@ -132,9 +132,9 @@ async def test_process_announcement_missing_end_time(ai_processor):
 
         result = await ai_processor.process_announcement("Test message")
 
-        assert result['success'] is True
+        assert result.success is True
         # Check if end time is start time + 1 hour
-        assert result['event_end_timestamp'] == result['event_start_timestamp'] + 3600
+        assert result.event_end_timestamp == result.event_start_timestamp + 3600
 
 @pytest.mark.asyncio
 async def test_process_announcement_missing_required_fields(ai_processor):
@@ -152,5 +152,5 @@ async def test_process_announcement_missing_required_fields(ai_processor):
 
         result = await ai_processor.process_announcement("Test message")
 
-        assert result['success'] is False
-        assert "抽出が失敗しました" in result['error']
+        assert result.success is False
+        assert "抽出が失敗しました" in result.error

--- a/tests/test_announcement_state.py
+++ b/tests/test_announcement_state.py
@@ -1,0 +1,116 @@
+import pytest
+from unittest.mock import AsyncMock
+from utils.announcement_state import AnnouncementState
+
+
+@pytest.fixture
+def state():
+    return AnnouncementState(max_history=5)
+
+
+@pytest.fixture
+def mock_persistence():
+    persistence = AsyncMock()
+    persistence.save_data = AsyncMock()
+    persistence.load_data = AsyncMock()
+    return persistence
+
+
+class TestAnnouncementState:
+    def test_add_pending(self, state):
+        state.add_pending("msg1")
+        assert state.is_pending("msg1")
+        assert state.get_bot_reply_id("msg1") is None
+
+    def test_mark_queued(self, state):
+        state.add_pending("msg1")
+        state.mark_queued("msg1", "reply1")
+        assert state.is_queued("msg1")
+        assert state.get_bot_reply_id("msg1") == "reply1"
+
+    def test_mark_completed(self, state):
+        state.add_pending("msg1")
+        state.mark_queued("msg1", "reply1")
+        state.mark_completed("msg1")
+        assert state.is_in_history("msg1")
+        assert not state.is_queued("msg1")
+        assert not state.is_pending("msg1")
+
+    def test_history_limit(self, state):
+        for i in range(10):
+            state.mark_completed(f"msg{i}")
+        assert len(state.history) == 5
+        assert state.history[0] == "msg5"
+        assert state.history[-1] == "msg9"
+
+    def test_cancel(self, state):
+        state.add_pending("msg1")
+        state.mark_queued("msg1", "reply1")
+        state.set_calendar_event("msg1", "cal1")
+
+        calendar_id = state.cancel("msg1")
+
+        assert calendar_id == "cal1"
+        assert not state.is_queued("msg1")
+        assert state.is_pending("msg1")
+        assert state.get_bot_reply_id("msg1") is None
+        assert not state.has_calendar_event("msg1")
+
+    def test_cancel_without_calendar(self, state):
+        state.add_pending("msg1")
+        state.mark_queued("msg1", "reply1")
+
+        calendar_id = state.cancel("msg1")
+
+        assert calendar_id is None
+        assert not state.is_queued("msg1")
+
+    def test_find_request_id_by_bot_message(self, state):
+        state.add_pending("msg1")
+        state.mark_queued("msg1", "reply1")
+        state.add_pending("msg2")
+        state.mark_queued("msg2", "reply2")
+
+        assert state.find_request_id_by_bot_message("reply1") == "msg1"
+        assert state.find_request_id_by_bot_message("reply2") == "msg2"
+        assert state.find_request_id_by_bot_message("unknown") is None
+
+    def test_calendar_events(self, state):
+        state.set_calendar_event("msg1", "cal1")
+        assert state.has_calendar_event("msg1")
+        assert state.get_calendar_event_id("msg1") == "cal1"
+
+        removed = state.remove_calendar_event("msg1")
+        assert removed == "cal1"
+        assert not state.has_calendar_event("msg1")
+
+    def test_remove_nonexistent_calendar_event(self, state):
+        assert state.remove_calendar_event("msg1") is None
+
+    @pytest.mark.asyncio
+    async def test_save(self, state, mock_persistence):
+        state.add_pending("msg1")
+        state.history.append("msg0")
+        state.set_calendar_event("msg2", "cal2")
+
+        await state.save(mock_persistence)
+
+        assert mock_persistence.save_data.call_count == 3
+        calls = mock_persistence.save_data.call_args_list
+        assert calls[0].args == ('pending', state.pending_requests)
+        assert calls[1].args == ('history', state.history)
+        assert calls[2].args == ('calendar', state.calendar_events)
+
+    @pytest.mark.asyncio
+    async def test_load(self, state, mock_persistence):
+        mock_persistence.load_data.side_effect = [
+            {'msg1': 'reply1'},
+            ['msg0'],
+            {'msg2': 'cal2'},
+        ]
+
+        await state.load(mock_persistence)
+
+        assert state.pending_requests == {'msg1': 'reply1'}
+        assert state.history == ['msg0']
+        assert state.calendar_events == {'msg2': 'cal2'}

--- a/tests/test_auth_retry.py
+++ b/tests/test_auth_retry.py
@@ -2,6 +2,7 @@ import asyncio
 import unittest
 from unittest.mock import MagicMock, AsyncMock, patch
 from utils.vrchat_api import VRChatAPI
+from utils.models import AuthResult, ApiResult
 from vrchatapi.exceptions import UnauthorizedException, ApiException
 from utils.messages import Messages
 
@@ -51,7 +52,7 @@ class TestVRChatAPIAuth(unittest.IsolatedAsyncioTestCase):
         result = await self.api._authenticate()
 
         # Verify
-        self.assertTrue(result['success'])
+        self.assertTrue(result.success)
         self.assertEqual(auth_api.verify2_fa.call_count, 2)
         self.assertEqual(self.api.otp_callback.call_count, 2)
 
@@ -65,14 +66,14 @@ class TestVRChatAPIAuth(unittest.IsolatedAsyncioTestCase):
         auth_api.get_current_user.side_effect = unauth_exc
 
         # Mock _authenticate to succeed
-        self.api._authenticate = AsyncMock(return_value={'success': True, 'reauthenticated': True})
+        self.api._authenticate = AsyncMock(return_value=AuthResult(success=True, reauthenticated=True))
 
         # Run
         result = await self.api.check_auth_status()
 
         # Verify
-        self.assertTrue(result['success'])
-        self.assertTrue(result.get('reauthenticated'))
+        self.assertTrue(result.success)
+        self.assertTrue(result.reauthenticated)
         self.api._authenticate.assert_called_once()
 
     @patch('utils.vrchat_api.GroupsApi')
@@ -89,13 +90,13 @@ class TestVRChatAPIAuth(unittest.IsolatedAsyncioTestCase):
         ]
 
         # Mock _authenticate to succeed
-        self.api._authenticate = AsyncMock(return_value={'success': True})
+        self.api._authenticate = AsyncMock(return_value=AuthResult(success=True))
 
         # Run
         result = await self.api.post_announcement("Title", "Content")
 
         # Verify
-        self.assertTrue(result['success'])
+        self.assertTrue(result.success)
         self.assertEqual(groups_api.add_group_post.call_count, 2)
         self.api._authenticate.assert_called_once()
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -35,11 +35,11 @@ async def test_schedule_announcement_stores_event_title(scheduler):
     assert job_id in scheduler.jobs
     job = scheduler.jobs[job_id]
 
-    assert job['event_start_timestamp'] == start_ts
-    assert job['event_end_timestamp'] == end_ts
-    assert job['message_id'] == "msg_123"
-    assert job['title'] == "Application Title"
-    assert job['event_title'] == "Event Title"
+    assert job.event_start_timestamp == start_ts
+    assert job.event_end_timestamp == end_ts
+    assert job.message_id == "msg_123"
+    assert job.title == "Application Title"
+    assert job.event_title == "Event Title"
 
 @pytest.mark.asyncio
 async def test_schedule_announcement_default_event_title(scheduler):
@@ -54,8 +54,8 @@ async def test_schedule_announcement_default_event_title(scheduler):
     )
 
     job = scheduler.jobs[job_id]
-    assert job['title'] == "Application Title"
-    assert job['event_title'] == "Application Title" # Should default to title
+    assert job.title == "Application Title"
+    assert job.event_title == "Application Title" # Should default to title
 
 @pytest.mark.asyncio
 async def test_scheduler_persistence_format(scheduler):
@@ -100,7 +100,7 @@ async def test_restore_jobs(scheduler):
     assert restored == 1
     assert skipped == []
     assert 'job_1' in scheduler.jobs
-    assert scheduler.jobs['job_1']['event_title'] == 'Restored Event Title'
+    assert scheduler.jobs['job_1'].event_title == 'Restored Event Title'
 
 @pytest.mark.asyncio
 async def test_restore_legacy_jobs(scheduler):
@@ -121,4 +121,4 @@ async def test_restore_legacy_jobs(scheduler):
     assert restored == 1
     assert 'job_legacy' in scheduler.jobs
     # Should default event_title to title
-    assert scheduler.jobs['job_legacy']['event_title'] == 'Legacy Job'
+    assert scheduler.jobs['job_legacy'].event_title == 'Legacy Job'

--- a/utils/ai_processor.py
+++ b/utils/ai_processor.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta
 import pytz
 from dateutil import parser
 from utils.messages import Messages
+from utils.models import AIProcessingResult
 
 logger = logging.getLogger(__name__)
 
@@ -16,20 +17,20 @@ class AIProcessor:
         openai.api_key = self.api_key
         openai.api_base = "https://openrouter.ai/api/v1"
         
-    async def process_announcement(self, message_content):
+    async def process_announcement(self, message_content) -> AIProcessingResult:
         """Process the announcement message and extract details"""
         try:
             logger.info(Messages.Log.AI_PROCESSING)
-            
+
             # Prepare the prompt
             prompt = self.prompt.replace("__message_content__", message_content)
-            
+
             # Call OpenRouter API
             headers = {
                 "HTTP-Referer": "https://vrchat-announce-bot.example.com",
                 "X-Title": "VRChat Announcement Bot"
             }
-            
+
             response = await openai.AsyncOpenAI(
                 base_url="https://openrouter.ai/api/v1",
                 api_key=self.api_key,
@@ -40,11 +41,11 @@ class AIProcessor:
                     {"role": "user", "content": prompt}
                 ]
             )
-            
+
             # Extract the response
             ai_response = response.choices[0].message.content
             logger.info(Messages.Log.AI_RAW_RESPONSE.format(ai_response))
-            
+
             # Clean up markdown if present
             if "```" in ai_response:
                 # Extract content between code blocks
@@ -54,16 +55,16 @@ class AIProcessor:
                         if ai_response.startswith("json"):
                             ai_response = ai_response[4:].strip()
                         break
-            
+
             # Parse the JSON
             parsed_response = json.loads(ai_response)
             logger.info(Messages.Log.AI_PARSED_RESPONSE.format(parsed_response))
-            
+
             jst = pytz.timezone('Asia/Tokyo')
-            
+
             # Extract Announcement Time
             if not parsed_response.get('announcement_date') or not parsed_response.get('announcement_time'):
-                 return {"success": False, "error": Messages.Error.AI_ANNOUNCEMENT_TIME_FAIL}
+                return AIProcessingResult(success=False, error=Messages.Error.AI_ANNOUNCEMENT_TIME_FAIL)
 
             ann_dt_str = f"{parsed_response['announcement_date']} {parsed_response['announcement_time']}"
             ann_dt = parser.parse(ann_dt_str)
@@ -72,7 +73,7 @@ class AIProcessor:
 
             # Extract Event Start Time
             if not parsed_response.get('event_start_date') or not parsed_response.get('event_start_time'):
-                 return {"success": False, "error": Messages.Error.AI_EVENT_TIME_FAIL}
+                return AIProcessingResult(success=False, error=Messages.Error.AI_EVENT_TIME_FAIL)
 
             event_start_str = f"{parsed_response['event_start_date']} {parsed_response['event_start_time']}"
             event_start_dt = parser.parse(event_start_str)
@@ -93,22 +94,22 @@ class AIProcessor:
             # Extract title and event_title, applying truncation
             title = parsed_response["title"][:128]
             event_title = parsed_response.get("event_title", title)
-            if not event_title: # Handle empty string case
-                 event_title = title
+            if not event_title:
+                event_title = title
             event_title = event_title[:128]
 
-            return {
-                "success": True,
-                "timestamp": announcement_timestamp, # Kept for backward compatibility logic in cog
-                "announcement_timestamp": announcement_timestamp,
-                "event_start_timestamp": event_start_timestamp,
-                "event_end_timestamp": event_end_timestamp,
-                "formatted_date_time": ann_dt.strftime('%Y年%m月%d日 %H:%M'),
-                "title": title,
-                "event_title": event_title,
-                "content": parsed_response["content"]
-            }
-            
+            return AIProcessingResult(
+                success=True,
+                timestamp=announcement_timestamp,
+                announcement_timestamp=announcement_timestamp,
+                event_start_timestamp=event_start_timestamp,
+                event_end_timestamp=event_end_timestamp,
+                formatted_date_time=ann_dt.strftime('%Y年%m月%d日 %H:%M'),
+                title=title,
+                event_title=event_title,
+                content=parsed_response["content"],
+            )
+
         except Exception as e:
             logger.error(Messages.Log.AI_PROCESS_ERROR.format(e))
-            return {"success": False, "error": Messages.Error.AI_ERROR.format(str(e))}
+            return AIProcessingResult(success=False, error=Messages.Error.AI_ERROR.format(str(e)))

--- a/utils/announcement_state.py
+++ b/utils/announcement_state.py
@@ -1,0 +1,82 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class AnnouncementState:
+    """Encapsulates all announcement tracking state with clear transitions."""
+
+    def __init__(self, max_history=1000):
+        self.pending_requests: dict[str, str | None] = {}   # msg_id -> bot_reply_id
+        self.queued_announcements: set[str] = set()
+        self.history: list[str] = []
+        self.calendar_events: dict[str, str] = {}           # msg_id -> calendar_event_id
+        self._max_history = max_history
+
+    # --- Queries ---
+
+    def is_pending(self, msg_id: str) -> bool:
+        return msg_id in self.pending_requests
+
+    def is_queued(self, msg_id: str) -> bool:
+        return msg_id in self.queued_announcements
+
+    def is_in_history(self, msg_id: str) -> bool:
+        return msg_id in self.history
+
+    def has_calendar_event(self, msg_id: str) -> bool:
+        return msg_id in self.calendar_events
+
+    def get_calendar_event_id(self, msg_id: str) -> str | None:
+        return self.calendar_events.get(msg_id)
+
+    def get_bot_reply_id(self, msg_id: str) -> str | None:
+        return self.pending_requests.get(msg_id)
+
+    def find_request_id_by_bot_message(self, bot_msg_id: str) -> str | None:
+        """Reverse lookup: given a bot reply message ID, find the original request msg_id."""
+        for req_id, reply_id in self.pending_requests.items():
+            if reply_id == bot_msg_id:
+                return req_id
+        return None
+
+    # --- Transitions ---
+
+    def add_pending(self, msg_id: str) -> None:
+        self.pending_requests[msg_id] = None
+
+    def mark_queued(self, msg_id: str, bot_reply_id: str) -> None:
+        self.pending_requests[msg_id] = bot_reply_id
+        self.queued_announcements.add(msg_id)
+
+    def mark_completed(self, msg_id: str) -> None:
+        if msg_id not in self.history:
+            self.history.append(msg_id)
+            if len(self.history) > self._max_history:
+                self.history = self.history[-self._max_history:]
+        self.queued_announcements.discard(msg_id)
+        self.pending_requests.pop(msg_id, None)
+
+    def cancel(self, msg_id: str) -> str | None:
+        """Cancel a queued announcement. Returns calendar_event_id if one existed."""
+        self.queued_announcements.discard(msg_id)
+        self.pending_requests[msg_id] = None
+        return self.calendar_events.pop(msg_id, None)
+
+    def set_calendar_event(self, msg_id: str, event_id: str) -> None:
+        self.calendar_events[msg_id] = event_id
+
+    def remove_calendar_event(self, msg_id: str) -> str | None:
+        return self.calendar_events.pop(msg_id, None)
+
+    # --- Persistence ---
+
+    async def save(self, persistence) -> None:
+        await persistence.save_data('pending', self.pending_requests)
+        await persistence.save_data('history', self.history)
+        await persistence.save_data('calendar', self.calendar_events)
+
+    async def load(self, persistence) -> None:
+        self.pending_requests = await persistence.load_data('pending', {})
+        self.history = await persistence.load_data('history', [])
+        self.calendar_events = await persistence.load_data('calendar', {})

--- a/utils/models.py
+++ b/utils/models.py
@@ -1,0 +1,65 @@
+from dataclasses import dataclass, field, asdict
+from typing import Any
+
+
+@dataclass
+class AuthResult:
+    success: bool
+    error: str | None = None
+    user_id: str | None = None
+    display_name: str | None = None
+    method: str | None = None
+    reauthenticated: bool = False
+
+
+@dataclass
+class ApiResult:
+    success: bool
+    error: str | None = None
+    data: dict[str, Any] | None = None
+
+
+@dataclass
+class AIProcessingResult:
+    success: bool
+    error: str | None = None
+    timestamp: int | None = None
+    announcement_timestamp: int | None = None
+    event_start_timestamp: int | None = None
+    event_end_timestamp: int | None = None
+    formatted_date_time: str | None = None
+    title: str | None = None
+    event_title: str | None = None
+    content: str | None = None
+
+
+@dataclass
+class JobData:
+    id: str
+    message_id: str
+    timestamp: float
+    title: str
+    content: str
+    status: str = "pending"
+    event_start_timestamp: float | None = None
+    event_end_timestamp: float | None = None
+    event_title: str | None = None
+    formatted_date_time: str | None = None
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "JobData":
+        return cls(
+            id=d["id"],
+            message_id=d["message_id"],
+            timestamp=d["timestamp"],
+            title=d["title"],
+            content=d["content"],
+            status=d.get("status", "pending"),
+            event_start_timestamp=d.get("event_start_timestamp"),
+            event_end_timestamp=d.get("event_end_timestamp"),
+            event_title=d.get("event_title"),
+            formatted_date_time=d.get("formatted_date_time"),
+        )

--- a/utils/scheduler.py
+++ b/utils/scheduler.py
@@ -5,6 +5,7 @@ import pytz
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.jobstores.memory import MemoryJobStore
 from utils.messages import Messages
+from utils.models import JobData
 
 logger = logging.getLogger(__name__)
 
@@ -44,18 +45,17 @@ class Scheduler:
         if event_title is None:
             event_title = title
 
-        self.jobs[job_id] = {
-            'id': job_id,
-            'message_id': message_id,
-            'timestamp': timestamp,
-            'event_start_timestamp': event_start_timestamp,
-            'event_end_timestamp': event_end_timestamp,
-            'formatted_date_time': datetime.fromtimestamp(timestamp).strftime('%Y年%m月%d日 %H:%M'),
-            'title': title,
-            'event_title': event_title,
-            'content': content,
-            'status': 'pending'  # pending, success, failed
-        }
+        self.jobs[job_id] = JobData(
+            id=job_id,
+            message_id=message_id,
+            timestamp=timestamp,
+            event_start_timestamp=event_start_timestamp,
+            event_end_timestamp=event_end_timestamp,
+            formatted_date_time=datetime.fromtimestamp(timestamp).strftime('%Y年%m月%d日 %H:%M'),
+            title=title,
+            event_title=event_title,
+            content=content,
+        )
         
         return job_id
         
@@ -67,34 +67,32 @@ class Scheduler:
             # Re-authenticate if needed
             if not self.vrchat_api.authenticated:
                 auth_result = await self.vrchat_api.initialize()
-                if not auth_result['success']:
-                    logger.error(Messages.Log.JOB_AUTH_FAIL.format(job_id, auth_result['error']))
-                    self.jobs[job_id]['status'] = 'failed'
-                    # Notify callback to persist the failure
+                if not auth_result.success:
+                    logger.error(Messages.Log.JOB_AUTH_FAIL.format(job_id, auth_result.error))
+                    self.jobs[job_id].status = 'failed'
                     if self.on_job_completion:
-                        await self.on_job_completion(self.jobs[job_id].copy())
+                        await self.on_job_completion(self.jobs[job_id].to_dict())
                     return
 
             # Post the announcement
             result = await self.vrchat_api.post_announcement(title, content)
 
-            if result['success']:
-                logger.info(Messages.Log.POST_SUCCESS.format(result.get('post_id', 'N/A')))
-                self.jobs[job_id]['status'] = 'success'
+            if result.success:
+                logger.info(Messages.Log.POST_SUCCESS.format('N/A'))
+                self.jobs[job_id].status = 'success'
             else:
-                logger.error(Messages.Log.POST_FAIL.format(result['error']))
-                self.jobs[job_id]['status'] = 'failed'
+                logger.error(Messages.Log.POST_FAIL.format(result.error))
+                self.jobs[job_id].status = 'failed'
 
                 # If authentication failed, we'll retry after reauth
-                if "Authentication failed" in result['error']:
-                    # The post will be automatically retried after reauth
+                if "Authentication failed" in result.error:
                     return
 
             # Copy job data before potential deletion
-            job_data = self.jobs[job_id].copy()
+            job_data = self.jobs[job_id].to_dict()
 
             # Remove the job from the jobs dictionary if it succeeded
-            if self.jobs[job_id]['status'] == 'success':
+            if self.jobs[job_id].status == 'success':
                 del self.jobs[job_id]
 
             # Notify callback for both success and failure to persist state
@@ -104,10 +102,9 @@ class Scheduler:
         except Exception as e:
             logger.error(Messages.Log.JOB_EXEC_ERROR.format(job_id, e))
             if job_id in self.jobs:
-                self.jobs[job_id]['status'] = 'failed'
-                # Notify callback to persist the failure
+                self.jobs[job_id].status = 'failed'
                 if self.on_job_completion:
-                    await self.on_job_completion(self.jobs[job_id].copy())
+                    await self.on_job_completion(self.jobs[job_id].to_dict())
     
     def restore_jobs(self, jobs_list):
         """Restore jobs from storage. Returns (restored_count, skipped_jobs_list)"""
@@ -138,7 +135,7 @@ class Scheduler:
                 if 'event_title' not in job_data:
                     job_data['event_title'] = job_data['title']
 
-                self.jobs[job_id] = job_data
+                self.jobs[job_id] = JobData.from_dict(job_data)
                 restored_count += 1
                 logger.info(f"Restored job {job_id} scheduled for {run_date}")
 
@@ -149,22 +146,21 @@ class Scheduler:
 
     def get_jobs_data(self):
         """Get list of current jobs for persistence"""
-        return list(self.jobs.values())
+        return [job.to_dict() for job in self.jobs.values()]
 
     def list_jobs(self):
         """List all active scheduled jobs"""
         active_jobs = []
         for job in self.jobs.values():
-            # Check if the job still exists in the scheduler
-            if self.scheduler.get_job(job['id']) is not None:
+            if self.scheduler.get_job(job.id) is not None:
                 active_jobs.append(job)
         return active_jobs
-    
+
     def cancel_job(self, job_id):
         """Cancel a scheduled job"""
         if job_id not in self.jobs:
             return False
-        
+
         try:
             self.scheduler.remove_job(job_id)
             del self.jobs[job_id]
@@ -172,18 +168,18 @@ class Scheduler:
         except Exception as e:
             logger.error(Messages.Log.JOB_CANCEL_ERROR.format(job_id, e))
             return False
-    
+
     def cancel_job_by_message_id(self, message_id):
         """Cancel a scheduled job by message ID"""
         for job_id, job in list(self.jobs.items()):
-            if job['message_id'] == message_id:
+            if job.message_id == message_id:
                 return self.cancel_job(job_id)
         return False
 
     def get_job_by_message_id(self, message_id):
         """Get a scheduled job by message ID"""
         for job in self.jobs.values():
-            if job['message_id'] == message_id:
+            if job.message_id == message_id:
                 return job
         return None
     

--- a/uv.lock
+++ b/uv.lock
@@ -2614,7 +2614,7 @@ wheels = [
 
 [[package]]
 name = "vrchat-announce-bot"
-version = "2.1.2"
+version = "2.2.0"
 source = { virtual = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
## Summary

- **Typed data models** (`utils/models.py`): Replace all loose `dict` returns with dataclasses (`AuthResult`, `ApiResult`, `AIProcessingResult`, `JobData`) so fields are documented and IDE-discoverable
- **Auth-retry helper** (`_with_auth_retry`): Eliminate ~120 lines of duplicated try/UnauthorizedException/reauth/retry boilerplate across VRChat API methods — each method now defines only business logic
- **Announcement state manager** (`utils/announcement_state.py`): Encapsulate 4 implicit state dicts into a class with clear query/transition/persistence methods; eliminates duplicated reverse-lookup loops
- **Remove dead OTP code** from `bot.py`: The cog's OTP callback already overwrites the bot's, making the bot's `_request_otp` and `on_message` OTP block dead code (~35 lines removed)
- **Reaction handler refactoring**: Split monolithic `on_raw_reaction_add` (90+ lines) into focused `_handle_fast_forward_reaction`, `_handle_calendar_reaction`, `_handle_calendar_reaction_remove`, `_handle_approval_reaction_remove`; common permission check extracted to `_is_admin` / `_fetch_member_safe`
- **Break down long methods**: `_authenticate` (~95 lines) split into `_handle_2fa`, `_detect_2fa_type`, `_run_otp_loop`, `_verify_after_2fa`; `_process_approved_announcement` split via `_is_timestamp_too_old` and `_build_booking_embed`
- **Remove scheduler VRChat API leak**: `AnnouncementCog` now receives `vrchat_api` directly instead of accessing it through `self.scheduler.vrchat_api`

## Test plan

- [x] All existing tests pass (`uv run pytest` — 40 passed, 3 skipped)
- [x] New unit tests for `AnnouncementState` added (`tests/test_announcement_state.py`, 11 tests)
- [ ] Verify bot starts (`uv run python bot.py --env .env`) and responds to mention, approval reaction, fast-forward, calendar emoji, and OTP flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)