### PR TITLE
Add DM reaction filtering and improve job cancellation validation

### DIFF
--- a/cogs/announcement.py
+++ b/cogs/announcement.py
@@ -288,6 +288,10 @@ class AnnouncementCog(commands.Cog):
         if payload.user_id == self.bot.user.id:
             return
 
+        # Ignore DM reactions (guild_id is None for DMs)
+        if payload.guild_id is None:
+            return
+
         # Check if the channel is a monitored channel
         if str(payload.channel_id) not in self._all_channel_ids:
             return
@@ -370,6 +374,10 @@ class AnnouncementCog(commands.Cog):
         """Handle reaction removals"""
         # Ignore own reactions
         if payload.user_id == self.bot.user.id:
+            return
+
+        # Ignore DM reactions (guild_id is None for DMs)
+        if payload.guild_id is None:
             return
 
         # Check if the channel is a monitored channel

--- a/tests/test_cogs.py
+++ b/tests/test_cogs.py
@@ -222,6 +222,44 @@ class TestCogs:
         args, _ = mock_context.reply.call_args
         assert Messages.Discord.JOB_CANCELLED.format("job1") in args[0]
 
+    @pytest.mark.asyncio
+    async def test_admin_cancel_cross_guild_rejected(self, admin_cog, mock_context, mock_admin_member):
+        """Test that cancelling a job belonging to a different guild is rejected."""
+        mock_context.author = mock_admin_member
+
+        # The mock scheduler returns a job with guild_id = str(TEST_GUILD_ID),
+        # but the context guild is different.
+        other_guild_id = 999999999
+        mock_context.guild.id = other_guild_id
+
+        await admin_cog.cancel_job(admin_cog, mock_context, "job1")
+
+        # Verify cancel_job was NOT called on the scheduler
+        admin_cog.scheduler.cancel_job.assert_not_called()
+
+        # Verify the "not found" message was sent
+        mock_context.reply.assert_called_once()
+        args, _ = mock_context.reply.call_args
+        assert Messages.Discord.JOB_NOT_FOUND.format("job1") in args[0]
+
+    @pytest.mark.asyncio
+    async def test_admin_cancel_nonexistent_job_rejected(self, admin_cog, mock_context, mock_admin_member):
+        """Test that cancelling a nonexistent job is rejected."""
+        mock_context.author = mock_admin_member
+
+        # Make get_job return None for the requested job
+        admin_cog.scheduler.get_job = MagicMock(return_value=None)
+
+        await admin_cog.cancel_job(admin_cog, mock_context, "nonexistent_job")
+
+        # Verify cancel_job was NOT called on the scheduler
+        admin_cog.scheduler.cancel_job.assert_not_called()
+
+        # Verify the "not found" message was sent
+        mock_context.reply.assert_called_once()
+        args, _ = mock_context.reply.call_args
+        assert Messages.Discord.JOB_NOT_FOUND.format("nonexistent_job") in args[0]
+
     # AnnouncementCog Tests
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
This PR improves the robustness of the announcement cog's reaction handling and adds comprehensive validation for the admin job cancellation command.

## Key Changes

### Announcement Cog - DM Reaction Filtering
- Added checks in `on_raw_reaction_add()` and `on_raw_reaction_remove()` to ignore reactions from direct messages
- DMs are identified by checking if `payload.guild_id is None`
- Prevents unnecessary processing of DM reactions that aren't relevant to monitored channels

### Admin Cog - Job Cancellation Validation
- Added test coverage for cross-guild job cancellation attempts
  - Verifies that jobs belonging to different guilds cannot be cancelled
  - Ensures the scheduler's `cancel_job()` is not called for cross-guild requests
  - Confirms appropriate "job not found" error message is returned
- Added test coverage for nonexistent job cancellation attempts
  - Verifies that attempting to cancel a job that doesn't exist is properly rejected
  - Ensures the scheduler's `cancel_job()` is not called
  - Confirms appropriate "job not found" error message is returned

## Implementation Details
- The DM filtering is placed early in the reaction event handlers to short-circuit unnecessary processing
- Job cancellation validation tests follow the existing test patterns and use appropriate mocking
- Both changes maintain backward compatibility and improve security/reliability

https://claude.ai/code/session_01WyEAdkGB2JSBE9aWHdy3bZ