### PR TITLE
fix: case-insensitive username comparison and duplicate logging

### DIFF
--- a/utils/vrchat_api.py
+++ b/utils/vrchat_api.py
@@ -1,6 +1,5 @@
 import logging
 import vrchatapi
-import sys
 from datetime import datetime
 import pytz
 from vrchatapi.api.authentication_api import AuthenticationApi
@@ -13,14 +12,6 @@ from utils.messages import Messages
 from utils.models import AuthResult, ApiResult
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
-
-# Add a console handler to ensure logs are output immediately
-console_handler = logging.StreamHandler(sys.stdout)
-console_handler.setLevel(logging.INFO)
-formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-console_handler.setFormatter(formatter)
-logger.addHandler(console_handler)
 
 class VRChatAPI:
     def __init__(self, config, persistence):
@@ -43,7 +34,7 @@ class VRChatAPI:
         # Try to authenticate with saved cookies first
         if await self._try_cookie_auth():
             # Verify the cached session belongs to the configured account
-            if self.current_user.username != self.username:
+            if self.current_user.username.lower() != self.username.lower():
                 logger.warning(Messages.Log.USERNAME_MISMATCH.format(
                     self.current_user.username, self.username))
                 await self._invalidate_cookies()
@@ -334,7 +325,7 @@ class VRChatAPI:
             self.authenticated = True
 
             # Verify the session belongs to the configured account
-            if self.current_user.username != self.username:
+            if self.current_user.username.lower() != self.username.lower():
                 logger.warning(Messages.Log.USERNAME_MISMATCH.format(
                     self.current_user.username, self.username))
                 await self._invalidate_cookies()


### PR DESCRIPTION
## Summary
- Use case-insensitive comparison for VRChat username validation — the API returns lowercase (`inkutech`) while config may have mixed case (`InkuTech`), causing unnecessary session invalidation and re-auth on every startup
- Remove redundant `StreamHandler` in `vrchat_api.py` that duplicated every log line (root logger from `bot.py` already handles console output)

## Test plan
- [ ] Verify bot starts without "Cookie session belongs to..." warning when config username differs only in case
- [ ] Verify log lines appear only once

🤖 Generated with [Claude Code](https://claude.com/claude-code)