### PR TITLE
Support configurable Firestore database ID for dev

### DIFF
--- a/.prd.env.template
+++ b/.prd.env.template
@@ -1,11 +1,13 @@
 # Discord Credentials
 DISCORD_TOKEN=your_discord_token_here
-DISCORD_ADMIN_ROLE_ID=your_admin_role_id_here
 
-# OpenRouter Credentials  
+# OpenRouter Credentials
 OPENROUTER_API_KEY=your_openrouter_key_here
 # Model is specified in config.yaml
 
 # VRChat Credentials
 VRCHAT_USERNAME=your_vrchat_username
 VRCHAT_PASSWORD=your_vrchat_password
+
+# Google Cloud (only needed when running outside GCP VMs)
+GOOGLE_APPLICATION_CREDENTIALS=path/to/service-account-key.json

--- a/bot.py
+++ b/bot.py
@@ -108,6 +108,7 @@ class VRChatAnnounceBot(commands.Bot):
             servers_collection=firestore_config.get('servers_collection', 'servers'),
             shared_collection=firestore_config.get('shared_collection', 'shared'),
             state_subcollection=firestore_config.get('state_subcollection', 'state'),
+            database=firestore_config.get('database'),
         )
 
         # Per-guild persistences for announcement state
@@ -165,6 +166,7 @@ class VRChatAnnounceBot(commands.Bot):
                 servers_collection=firestore_config.get('servers_collection', 'servers'),
                 shared_collection=firestore_config.get('shared_collection', 'shared'),
                 state_subcollection=firestore_config.get('state_subcollection', 'state'),
+                database=firestore_config.get('database'),
             )
         return persistences
 

--- a/config.yaml.template
+++ b/config.yaml.template
@@ -66,6 +66,7 @@ vrchat:
   heartbeat_interval: 60 # minutes
 
 firestore:
-  servers_collection: "servers"  # Top-level collection for per-guild state
-  shared_collection: "shared"    # Top-level collection for shared state (e.g. VRChat session)
-  state_subcollection: "state"   # Subcollection under each guild document
+  database: "(default)"            # Firestore database ID (use a different name for dev, e.g. "dev")
+  servers_collection: "servers"    # Top-level collection for per-guild state
+  shared_collection: "shared"      # Top-level collection for shared state (e.g. VRChat session)
+  state_subcollection: "state"     # Subcollection under each guild document

--- a/scripts/migrate_to_firestore.py
+++ b/scripts/migrate_to_firestore.py
@@ -47,8 +47,8 @@ def load_json(filepath):
         return json.load(f)
 
 
-async def migrate(server_id: str):
-    db = AsyncClient()
+async def migrate(server_id: str, database: str | None = None):
+    db = AsyncClient(database=database) if database else AsyncClient()
 
     # Migrate per-server state files
     for key, filename in STATE_FILES.items():
@@ -85,10 +85,15 @@ def main():
         default="default",
         help='Server ID in Firestore (default: "default")',
     )
+    parser.add_argument(
+        "--database",
+        default=None,
+        help='Firestore database ID (default: "(default)")',
+    )
     args = parser.parse_args()
 
-    logger.info(f"Starting migration with server_id={args.server_id}")
-    asyncio.run(migrate(args.server_id))
+    logger.info(f"Starting migration with server_id={args.server_id}, database={args.database or '(default)'}")
+    asyncio.run(migrate(args.server_id, database=args.database))
 
 
 if __name__ == "__main__":

--- a/utils/persistence.py
+++ b/utils/persistence.py
@@ -6,12 +6,13 @@ logger = logging.getLogger(__name__)
 
 class Persistence:
     def __init__(self, server_id='default', servers_collection='servers',
-                 shared_collection='shared', state_subcollection='state'):
+                 shared_collection='shared', state_subcollection='state',
+                 database=None):
         self.server_id = server_id
         self.servers_collection = servers_collection
         self.shared_collection = shared_collection
         self.state_subcollection = state_subcollection
-        self.db = AsyncClient()
+        self.db = AsyncClient(database=database) if database else AsyncClient()
 
     async def save_data(self, key, data):
         """Save per-server state to Firestore.


### PR DESCRIPTION
## Changes

- Add `database` configuration option to Firestore settings in `config.yaml.template`
- Update `Persistence` class to accept and use configurable `database` parameter when initializing Firestore `AsyncClient`
- Update bot initialization to pass `database` config to persistence instances
- Add `--database` CLI argument to migration script for dev environment support
- Update `.prd.env.template` with Google Cloud credentials path and formatting cleanup

## Purpose

Enables development environments to use separate Firestore databases (e.g., "dev") instead of the default database, preventing data conflicts between production and development instances.