### PR TITLE
docs: never push directly to main without explicit instruction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Rules
 
+- **Never push directly to `main`** unless explicitly told to do so. Always work on a feature branch and open a PR.
 - **Before starting any task**, check if the current branch is outdated relative to `origin/main`. Run `git fetch origin` and compare with `git log HEAD..origin/main --oneline`. If `origin/main` has commits not in the current branch, do not work on the stale branch. Instead, create a fresh branch from `origin/main` (`git checkout -b <branch-name> origin/main`) and work there. This avoids conflicts caused by intermediate commits already squash-merged into main.
 - If you are unable to run `uv` command, it is probably because the user's main shell is zsh. Try `source ~/.zshrc` in that case
 - Never ever implement any operation that deletes database entries which do not exceeds the maximum count, unless explicitly told to do that. Instead, ask for clarification or use flags


### PR DESCRIPTION
## Summary

- Adds a rule to `CLAUDE.md` prohibiting direct pushes to `main` unless explicitly instructed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)